### PR TITLE
PRI-503: Prepare for docker upgrade to docker-ce

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -10,9 +10,8 @@ docker_yum_repo_baseurl: 'https://yum.dockerproject.org/repo/main/centos/$releas
 
 # Used when package name is not docker-engine
 docker_package: docker-engine
-docker_package_version:  '*'    # specify '*' for latest version
+docker_package_version:  '17.05.0~ce-0~ubuntu-trusty'    # specify '*' for latest version
 
-docker_engine_version:  '*'    # specify '*' for latest version
 docker_api_version:     '1.10.6'
 docker_api_install:     false
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -8,9 +8,20 @@ docker_apt_repo: "deb https://apt.dockerproject.org/repo ubuntu-{{ ansible_distr
 docker_yum_gpg_key_url:  'https://yum.dockerproject.org/gpg'
 docker_yum_repo_baseurl: 'https://yum.dockerproject.org/repo/main/centos/$releasever/'
 
+# Used when package name is not docker-engine
+docker_package: docker-engine
+docker_package_version:  '*'    # specify '*' for latest version
+
 docker_engine_version:  '*'    # specify '*' for latest version
 docker_api_version:     '1.10.6'
 docker_api_install:     false
+
+## Example for installing docker-ce ########
+# docker_package: docker-ce
+# docker_apt_repo: "deb [arch=amd64] https://download.docker.com/linux/ubuntu {{ ansible_distribution_release }} stable"
+# docker_apt_key_id: '9DC858229FC7DD38854AE2D88D81803C0EBFCD88'
+# docker_package_version: '17.12.1~ce-0~ubuntu'
+# docker_api_version:     '3.1.0'
 
 ## Config
 docker_engine_opts: []

--- a/tasks/install-debian.yml
+++ b/tasks/install-debian.yml
@@ -28,8 +28,23 @@
 - name: Install apparmor
   apt: name=apparmor state=present
 
-- name: Install docker-engine
-  apt: name=docker-engine={{ docker_engine_version|default('*') }} state=present
+- name: Install docker package (docker-engine)
+  apt:
+    name: "{{ docker_package }}={{ docker_engine_version|default('*') }}"
+    state: present
+  when: docker_package == "docker-engine"
+
+- name: Ensure docker-engine not installed before installing other docker package (non-docker-engine)
+  apt:
+    name: docker-engine
+    state: absent
+  when: docker_package != "docker-engine"
+
+- name: Install docker package (non-docker-engine)
+  apt:
+    name: "{{ docker_package }}={{ docker_package_version|default('*') }}"
+    state: present
+  when: docker_package != "docker-engine"
 
 # WARN: docker-compose pip package >= 1.10.0 installs docker pip package which
 #       conflicts with docker-py required by Ansible docker_container module.

--- a/tasks/install-debian.yml
+++ b/tasks/install-debian.yml
@@ -28,23 +28,16 @@
 - name: Install apparmor
   apt: name=apparmor state=present
 
-- name: Install docker package (docker-engine)
-  apt:
-    name: "{{ docker_package }}={{ docker_engine_version|default('*') }}"
-    state: present
-  when: docker_package == "docker-engine"
-
-- name: Ensure docker-engine not installed before installing other docker package (non-docker-engine)
+- name: Ensure docker-engine not installed before installing other docker package
   apt:
     name: docker-engine
     state: absent
   when: docker_package != "docker-engine"
 
-- name: Install docker package (non-docker-engine)
+- name: Install docker package
   apt:
     name: "{{ docker_package }}={{ docker_package_version|default('*') }}"
     state: present
-  when: docker_package != "docker-engine"
 
 # WARN: docker-compose pip package >= 1.10.0 installs docker pip package which
 #       conflicts with docker-py required by Ansible docker_container module.

--- a/tasks/install-redhat.yml
+++ b/tasks/install-redhat.yml
@@ -24,11 +24,24 @@
     name: "epel-release"
     state: present
 
-- name: Install docker-engine
+- name: Install docker package (docker-engine)
   yum: 
     name: "docker-engine-{{ docker_engine_version|default('*') }}"
     update_cache: yes
     state: present
+  when: docker_package == "docker-engine"
+
+- name: Ensure docker-engine not installed before installing other docker package (non-docker-engine)
+  yum:
+    name: "docker-engine-{{ docker_engine_version|default('*') }}"
+    state: absent
+  when: docker_package != "docker-engine"
+
+- name: Install docker package (non-docker-engine)
+  yum:
+    name: {{ docker_package }}-{{ docker_package_version|default('*') }}
+    state: present
+  when: docker_package != "docker-engine"
 
 - name: Install python-pip
   yum: 

--- a/tasks/install-redhat.yml
+++ b/tasks/install-redhat.yml
@@ -24,24 +24,16 @@
     name: "epel-release"
     state: present
 
-- name: Install docker package (docker-engine)
-  yum: 
-    name: "docker-engine-{{ docker_engine_version|default('*') }}"
-    update_cache: yes
-    state: present
-  when: docker_package == "docker-engine"
-
-- name: Ensure docker-engine not installed before installing other docker package (non-docker-engine)
+- name: Ensure docker-engine not installed before installing other docker package
   yum:
-    name: "docker-engine-{{ docker_engine_version|default('*') }}"
+    name: "docker-engine"
     state: absent
   when: docker_package != "docker-engine"
 
-- name: Install docker package (non-docker-engine)
+- name: Install docker package
   yum:
     name: {{ docker_package }}-{{ docker_package_version|default('*') }}
     state: present
-  when: docker_package != "docker-engine"
 
 - name: Install python-pip
   yum: 


### PR DESCRIPTION
Package name has changed from docker-engine to docker-ce. We need to
support both until the whole environment has been upgraded